### PR TITLE
Added default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+  name = "myPythonEnv";
+  buildInputs = with pkgs; [
+    python37Full
+    python37Packages.virtualenv
+    python37Packages.ipykernel
+    jupyter
+  ];
+  src = null;
+  shellHook = ''
+    if [ ! -d .venv ]; then
+      python -m venv .venv
+    fi
+    source .venv/bin/activate
+    pip install --upgrade pip
+    if [ -s requirements.txt ]; then
+      pip install -r requirements.txt
+    fi
+    python -m ipykernel install --user --name=venv
+  '';
+}


### PR DESCRIPTION
Using this `default.nix`, people using the [nix toolchain](https://nixos.org/) can simply open a new `nix-shell` in the repository to autoinstall the dependencies into a python wirtual environment, and then run `jupyter notebook` in order to start working with a kernel that is using the `venv` from the project.