### PR TITLE
exercises/ex11_sourceSpace.md: Fix python package name

### DIFF
--- a/exercises/ex11_sourceSpace.md
+++ b/exercises/ex11_sourceSpace.md
@@ -14,7 +14,7 @@ We will skip these steps completly and start with an already-segment "default" M
  Source-reconstructions with a default-MRI (opposite of a individual MRI) introduces even more noise (=uncertainty) than already existing in "optimal" source localization. Your source-localizations should therefore be interpreted even more carefully than with individual MRIs. Never let yourself be fooled by the apparent precision of source-localizations!!
 
 # Setup
-We first need to install the python packages "pysurfer" and "pymayavi" - if pymayavi doesnt work,you can also try pyvista & pyvistaqt
+We first need to install the python packages "pysurfer" and "mayavi" - if mayavi doesnt work,you can also try pyvista & pyvistaqt
 
 ### !! 3D Frustration alert!! 
 3D Plots are annoying. They crash your system, they are slow, they are unstable. The frustration is normal and unfortunately still to be expected.


### PR DESCRIPTION
Fix package name of `mayavi` in Markdown description for easy:
`python3 -m pip install mayavi`
While for `pysurfer` the prefix `py` is required (in fact the package `surfer` exists as well and is a different, non-compatible one), `mayavi` has no prefix `py`:
https://pypi.org/project/mayavi/