### PR TITLE
Fix bug in Ex10 with indexing

### DIFF
--- a/exercises/ex10_decoding.ipynb
+++ b/exercises/ex10_decoding.ipynb
@@ -376,7 +376,7 @@
    "source": [
     "csp_data = csp.transform(epochs.get_data())\n",
     "\n",
-    "plt.scatter(csp_data[:,0],csp_data[:,2],color=np.array([\"red\",\"green\"])[labels-2])"
+    "plt.scatter(csp_data[:,0],csp_data[:,1],color=np.array([\"red\",\"green\"])[labels-2])"
    ]
   },
   {


### PR DESCRIPTION
In the box before, the size of csp_data has been printed as (45, 2). Hence, indexing should be [:,0] and [:,1].